### PR TITLE
Add canonical meta tag to application layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,12 +30,15 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Manage multiple processes i.e. web server and webpack
 gem 'foreman'
 
-# GOV.UK interpretation of rubocop for linting Ruby
-gem 'govuk-lint'
+# Canonical meta tag
+gem 'canonical-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+
+  # GOV.UK interpretation of rubocop for linting Ruby
+  gem 'govuk-lint'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    canonical-rails (0.2.4)
+      rails (>= 4.1, < 5.3)
     capybara (3.10.1)
       addressable
       mini_mime (>= 0.1.3)
@@ -218,6 +220,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  canonical-rails
   capybara (>= 2.15)
   chromedriver-helper
   foreman

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>RailsDfeBoilerplate</title>
+    <title>Rails DfE Boilerplate</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <%= canonical_tag %>
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
   </head>

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -1,0 +1,29 @@
+# Do yourself a favor and set these up right when you install the engine.
+
+CanonicalRails.setup do |config|
+
+  # Force the protocol. If you do not specify, the protocol will be based on the incoming request's protocol.
+
+  config.protocol= 'https://'
+
+  # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
+
+  config.host = 'www.education.gov.uk'
+  config.port# = '3000'
+
+  # http://en.wikipedia.org/wiki/URL_normalization
+  # Trailing slash represents semantics of a directory, ie a collection view - implying an :index get route;
+  # otherwise we have to assume semantics of an instance of a resource type, a member view - implying a :show get route
+  #
+  # Acts as a whitelist for routes to have trailing slashes
+
+  config.collection_actions# = [:index]
+
+  # Parameter spamming can cause index dilution by creating seemingly different URLs with identical or near-identical content.
+  # Unless whitelisted, these parameters will be omitted
+
+  config.whitelisted_parameters# = []
+
+  # Output a matching OpenGraph URL meta tag (og:url) with the canonical URL, as recommended by Facebook et al
+  config.opengraph_url= true
+end


### PR DESCRIPTION
### Context
SEO

### Changes proposed in this pull request
- Add canonical meta tag
- Move govuk-lint gem to development group in gemfile

### Guidance to review
Check source if there is a canonical meta tag 
